### PR TITLE
without quorum=true, we might read stale versions because we might read from a node that is lagging

### DIFF
--- a/config/etcd.lua
+++ b/config/etcd.lua
@@ -172,7 +172,7 @@ function M:recursive_extract(cut, node, storage)
 end
 
 function M:list(keyspath)
-	local res, response = self:request("GET","keys"..keyspath, { recursive = true })
+	local res, response = self:request("GET","keys"..keyspath, { recursive = true, quorum = true })
 	-- print(yaml.encode(res))
 	if res.node then
 		local result = self:recursive_extract(keyspath,res.node)
@@ -192,6 +192,7 @@ function M:wait(keyspath, args)
 	local _, response = self:request("GET","keys"..keyspath, {
 		wait = true,
 		recursive = true,
+		quorum = true,
 		timeout = args.timeout,
 		waitIndex = args.index,
 	})


### PR DESCRIPTION
without quorum=true, we might read stale versions because we might read from a node that is lagging. it's might be danger with switchover