### PR TITLE
Provides full support of raft bootstrap 

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,5 @@
 std = "tarantool"
 max_line_length = 200
+codes = true
 include_files = {"config.lua", "config/"}
+ignore = {"212"}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,3 @@
+std = "tarantool"
+max_line_length = 200
+include_files = {"config.lua", "config/"}

--- a/config.lua
+++ b/config.lua
@@ -331,12 +331,14 @@ master_selection_policies = {
 			if cluster_cfg.master == instance_name then
 				log.info("Instance is declared as cluster master, set read_only=false")
 				cfg.box.read_only = false
+				cfg.box.replication_connect_quorum = 1
+				cfg.box.replication_connect_timeout = 1
 			else
 				log.info("Cluster has another master %s, not me %s, set read_only=true", cluster_cfg.master, instance_name)
 				cfg.box.read_only = true
 			end
 		else
-			log.info("Claster have no declared master, set read_only=true")
+			log.info("Cluster have no declared master, set read_only=true")
 			cfg.box.read_only = true
 		end
 
@@ -842,10 +844,9 @@ local M
 								else
 									N_2_1 = 1+math.floor(n_ups/2)
 								end
-								cfg.box.replication_connect_quorum = math.max(
-									cfg.box.replication_connect_quorum or 0,
-									N_2_1
-								)
+								if not cfg.box.replication_connect_quorum then
+									cfg.box.replication_connect_quorum = N_2_1
+								end
 							end
 						end
 

--- a/config.lua
+++ b/config.lua
@@ -361,11 +361,16 @@ master_selection_policies = {
 		assert(cluster_cfg.replicaset_uuid,"Need cluster uuid")
 		cfg.box.replicaset_uuid = cluster_cfg.replicaset_uuid
 
+		if cfg.box.election_mode == 'off' or cfg.box.election_mode == nil then
+			log.info("Force box.read_only=true for election_mode=off")
+			cfg.box.read_only = true
+		end
+
 		if not cfg.box.election_mode then
-			cfg.box.election_mode = 'candidate'
+			cfg.box.election_mode = M.default_election_mode
 		end
 		if not cfg.box.replication_synchro_quorum then
-			cfg.box.replication_synchro_quorum = 'N/2+1'
+			cfg.box.replication_synchro_quorum = M.default_synchro_quorum
 		end
 
 		deep_merge(cfg, local_cfg)
@@ -610,9 +615,6 @@ local function is_replication_changed (old_conf, new_conf)
 end
 
 local M
---if rawget(_G,'config') then
---	M = rawget(_G,'config')
---else
 	M = setmetatable({
 		console = {};
 		get = function(self,k,def)
@@ -651,6 +653,8 @@ local M
 			if args.tidy_load == nil then
 				args.tidy_load = true
 			end
+			M.default_election_mode = args.default_election_mode or 'candidate'
+			M.default_synchro_quorum = args.default_synchro_quorum or 'N/2+1'
 			M.default_read_only = args.default_read_only or false
 			M.master_selection_policy = args.master_selection_policy
 			M.default = args.default
@@ -893,6 +897,5 @@ local M
 		end
 	})
 	rawset(_G,'config',M)
---end
 
 return M

--- a/config/etcd.lua
+++ b/config/etcd.lua
@@ -1,10 +1,7 @@
-local fiber = require 'fiber'
-local yaml = require 'yaml'
 local json = require 'json'
 local log = require 'log'
 
 local http_client = require 'http.client'
-local urilib = require('uri')
 local digest = require 'digest'
 
 local M = {}
@@ -31,14 +28,10 @@ function M.errstr(code)
 	return M.err[ tonumber(code) ] or string.format("Unknown error %s",code)
 end
 
-setmetatable(M,{
-	__call = function(M,...)
-		return M:new(...)
-	end
-})
+setmetatable(M,{ __call = M.new })
 
-function M.new(M,options)
-	local self = setmetatable({},{__index=M})
+function M.new(mod,options)
+	local self = setmetatable({},{__index=mod})
 	self.endpoints = options.endpoints or {'http://127.0.0.1:4001','http://127.0.0.1:2379'}
 	-- self.prefix    = options.prefix or ''
 	self.timeout   = options.timeout or 1


### PR DESCRIPTION
This patch enhances etcd.cluster.raft master selection policy to bootstrap RAFT cluster ignoring etcd.cluster.master setup phase.

Also, I fixed a lot of luacheck issues and generator of instance_uuid and replicaset_uuid to support single replicaset clusters.

As a result, I've completely fixed setting RCQ and RCT on bootstrapped instances to prevent instance freeze in orphan state in the end of recovery after fuckups. It also should speed up instance recovery and finally solve issue with RCQ/RCT