### PR TITLE
Assert etcd:list by "/"

### DIFF
--- a/config/etcd.lua
+++ b/config/etcd.lua
@@ -181,7 +181,7 @@ end
 function M:list(keyspath)
 	local res, response = self:request("GET","keys"..keyspath, { recursive = true, quorum = true })
 	-- print(yaml.encode(res))
-	if res.node then
+	if res.node and res.node.key then
 		local result = self:recursive_extract(keyspath,res.node)
 		-- todo: make it with metatable
 		-- print(yaml.encode(result))
@@ -189,6 +189,9 @@ function M:list(keyspath)
 		-- for _,n in pairs(res.node) do
 		-- 	print()
 		-- end
+	elseif res.node and (not res.node.key) then
+		-- Don't use "/" as a etcd prefix in config
+		error(('Failed to list keys by "%s", node.key is nil'):format(keyspath))
 	else
 		error(json.encode(res),2)
 	end


### PR DESCRIPTION
If you set an empty etcd prefix `/` in conf.lua, e.g:
```lua
etcd = {
    endpoints = {'http://etcd:2379'},
    prefix = '/',
}
```
you will get an error like this:

```
instance      | LuajitError: /instance/.rocks/share/tarantool/config/etcd.lua:148: bad argument #1 to 'sub' (string expected, got nil)
```

I think we can write an assert for this case.

Logs after:
```
instance      | LuajitError: /pairdb/.rocks/share/tarantool/config/etcd.lua:194: Failed to list keys by "/", node.key is nil
```
