### PR TITLE
Fix fencing

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,4 +2,5 @@ std = "tarantool"
 max_line_length = 200
 codes = true
 include_files = {"config.lua", "config/"}
+read_globals = {"config"}
 ignore = {"212"}

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,3 +2,4 @@ FROM tarantool/tarantool:2.10
 
 RUN apk add -u git cmake make gcc musl-dev
 RUN tarantoolctl rocks install luatest 0.5.7
+RUN tarantoolctl rocks install luacov-console

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,4 @@
+FROM tarantool/tarantool:2.10
+
+RUN apk add -u git cmake make gcc musl-dev
+RUN tarantoolctl rocks install luatest 0.5.7

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY := all test
+
+run-compose:
+	make -C test run-compose
+
+build-testing-image:
+	docker build -t config-test -f Dockerfile.test .
+
+test: build-testing-image run-compose
+	docker run --name config-test \
+		--net tt_net \
+		-e TT_ETCD_ENDPOINTS="http://etcd0:2379,http://etcd1:2379,http://etcd2:2379" \
+		--rm -v $$(pwd):/source/config \
+		--workdir /source/config \
+		--entrypoint '' \
+		config-test \
+		./run_test_in_docker.sh

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test: build-testing-image run-compose
 		--net tt_net \
 		-e TT_ETCD_ENDPOINTS="http://etcd0:2379,http://etcd1:2379,http://etcd2:2379" \
 		--rm -v $$(pwd):/source/config \
+		-v $$(pwd)/data:/tmp/ \
 		--workdir /source/config \
 		--entrypoint '' \
 		config-test \

--- a/config.lua
+++ b/config.lua
@@ -888,7 +888,7 @@ local M
 									cfg.box.replication_connect_quorum = optimal_rcq(cfg.box.replication)
 								end
 								log.info("Start non-bootstrapped tidy loading with ro=%s rcq=%s rct=%s (dir=%s)",
-									cfg.box.read_only, snap_dir, cfg.box.replication_connect_quorum, cfg.box.replication_connect_timeout)
+									cfg.box.read_only, cfg.box.replication_connect_quorum, cfg.box.replication_connect_timeout, snap_dir)
 							end
 						end
 

--- a/run_test_in_docker.sh
+++ b/run_test_in_docker.sh
@@ -2,4 +2,4 @@
 
 pwd
 rm -rf /root/.cache/
-.rocks/bin/luatest -c -v spec/01_single_test.lua
+.rocks/bin/luatest --coverage -c -v spec/01_single_test.lua

--- a/run_test_in_docker.sh
+++ b/run_test_in_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+pwd
+rm -rf /root/.cache/
+.rocks/bin/luatest -c -v spec/01_single_test.lua

--- a/spec/01_single_test.lua
+++ b/spec/01_single_test.lua
@@ -1,0 +1,131 @@
+local t = require 'luatest' --[[@as luatest]]
+local uri = require 'uri'
+local g = t.group('single')
+
+local this_file = debug.getinfo(1, "S").source:sub(2)
+local fio = require 'fio'
+
+local root = fio.dirname(this_file)
+
+local h = require 'spec.helper'
+local test_ctx = {}
+
+local working_dir
+
+g.before_each(function()
+	working_dir = h.create_workdir()
+end)
+
+g.after_each(function()
+	for _, info in pairs(test_ctx) do
+		for _, tt in pairs(info.tts) do
+			tt.tt:stop()
+		end
+	end
+
+	h.clean_directory(working_dir)
+	h.clear_etcd()
+end)
+
+function g.test_single_start()
+	test_ctx.single = { tts = {} }
+
+	local etcd_config = {
+		apps = {
+			single = {
+				common = { box = { log_level = 5 } },
+				instances = { single = { box = { listen = '127.0.0.1:3301' } } },
+			}
+		}
+	}
+
+	h.upload_to_etcd(etcd_config)
+
+	local env = {
+		TT_WAL_DIR = working_dir,
+		TT_MEMTX_DIR = working_dir,
+		TT_ETCD_PREFIX = '/apps/single',
+		TT_INSTANCE_NAME = 'single',
+		TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
+		TT_MASTER_SELECTION_POLICY = 'etcd.instance.single',
+		TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
+	}
+
+	local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
+
+	local tt = h.start_tarantool({
+		env = env,
+		command = init_lua,
+		args = {},
+		net_box_port = 3301,
+	})
+
+	test_ctx.single.tts = {{
+		tt = tt,
+	}}
+	tt:connect_net_box()
+
+	local box_cfg = tt:get_box_cfg()
+	t.assert_covers(box_cfg, {
+		log_level = 5,
+		listen = '127.0.0.1:3301',
+	})
+end
+
+function g.test_two_singles()
+	test_ctx.two_singles = { tts = {}, net_box_ports = {} }
+
+	local etcd_config = {
+		apps = {
+			single = {
+				common = { box = { log_level = 5 } },
+				instances = {
+					single_01 = { box = { listen = '127.0.0.1:3301' } },
+					single_02 = { box = { listen = '127.0.0.1:3302' } },
+				},
+			}
+		}
+	}
+
+	h.upload_to_etcd(etcd_config)
+
+	local base_env = {
+		TT_WAL_DIR = working_dir,
+		TT_MEMTX_DIR = working_dir,
+		TT_ETCD_PREFIX = '/apps/single',
+		TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
+		TT_MASTER_SELECTION_POLICY = 'etcd.instance.single',
+		TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
+	}
+	local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
+
+	for _, name in ipairs{'single_01', 'single_02'} do
+		local env = table.deepcopy(base_env)
+		env.TT_INSTANCE_NAME = name
+		local net_box_port = tonumber(uri.parse(etcd_config.apps.single.instances[name].box.listen).service)
+
+		local tt = h.start_tarantool({
+			env = env,
+			command = init_lua,
+			args = {},
+			net_box_port = net_box_port,
+		})
+
+		table.insert(test_ctx.two_singles.tts, {
+			tt = tt,
+			net_box_port = net_box_port,
+			env = env,
+			name = name,
+		})
+	end
+
+	for _, tt in ipairs(test_ctx.two_singles.tts) do
+		tt.tt:connect_net_box()
+		local box_cfg = tt.tt:get_box_cfg()
+		t.assert_covers(box_cfg, {
+			log_level = 5,
+			listen = etcd_config.apps.single.instances[tt.name].box.listen,
+		})
+	end
+end
+

--- a/spec/01_single_test.lua
+++ b/spec/01_single_test.lua
@@ -1,11 +1,40 @@
 local t = require 'luatest' --[[@as luatest]]
 local uri = require 'uri'
-local g = t.group('single')
+
+local base_config = {
+	apps = {
+		single = {
+			common = { box = { log_level = 4 } },
+		}
+	}
+}
+
+local g = t.group('single', {
+	{ instances = {single = '127.0.0.1:3301'}, run = {'single'} },
+	{
+		instances = {single_01 = '127.0.0.1:3301', single_02 = '127.0.0.1:3302'},
+		run = {'single_01', 'single_02'}
+	},
+	{
+		instances = {single_01 = '127.0.0.1:3301', single_02 = '127.0.0.1:3302'},
+		run = {'single_01'}
+	},
+})
 
 local this_file = debug.getinfo(1, "S").source:sub(2)
 local fio = require 'fio'
 
 local root = fio.dirname(this_file)
+local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
+
+local base_env = {
+	TT_WAL_DIR = nil, -- will be set at before_each trigger
+	TT_MEMTX_DIR = nil,  -- will be set at before_each trigger
+	TT_ETCD_PREFIX = '/apps/single',
+	TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
+	TT_MASTER_SELECTION_POLICY = 'etcd.instance.single',
+	TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
+}
 
 local h = require 'spec.helper'
 local test_ctx = {}
@@ -14,6 +43,8 @@ local working_dir
 
 g.before_each(function()
 	working_dir = h.create_workdir()
+	base_env.TT_WAL_DIR = working_dir
+	base_env.TT_MEMTX_DIR = working_dir
 end)
 
 g.after_each(function()
@@ -27,79 +58,20 @@ g.after_each(function()
 	h.clear_etcd()
 end)
 
-function g.test_single_start()
-	test_ctx.single = { tts = {} }
+function g.test_run_instances(cg)
+	local params = cg.params
+	local this_ctx = { tts = {} }
+	test_ctx[cg.name] = this_ctx
 
-	local etcd_config = {
-		apps = {
-			single = {
-				common = { box = { log_level = 5 } },
-				instances = { single = { box = { listen = '127.0.0.1:3301' } } },
-			}
-		}
-	}
-
-	h.upload_to_etcd(etcd_config)
-
-	local env = {
-		TT_WAL_DIR = working_dir,
-		TT_MEMTX_DIR = working_dir,
-		TT_ETCD_PREFIX = '/apps/single',
-		TT_INSTANCE_NAME = 'single',
-		TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
-		TT_MASTER_SELECTION_POLICY = 'etcd.instance.single',
-		TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
-	}
-
-	local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
-
-	local tt = h.start_tarantool({
-		env = env,
-		command = init_lua,
-		args = {},
-		net_box_port = 3301,
-	})
-
-	test_ctx.single.tts = {{
-		tt = tt,
-	}}
-	tt:connect_net_box()
-
-	local box_cfg = tt:get_box_cfg()
-	t.assert_covers(box_cfg, {
-		log_level = 5,
-		listen = '127.0.0.1:3301',
-	})
-end
-
-function g.test_two_singles()
-	test_ctx.two_singles = { tts = {}, net_box_ports = {} }
-
-	local etcd_config = {
-		apps = {
-			single = {
-				common = { box = { log_level = 5 } },
-				instances = {
-					single_01 = { box = { listen = '127.0.0.1:3301' } },
-					single_02 = { box = { listen = '127.0.0.1:3302' } },
-				},
-			}
-		}
-	}
+	local etcd_config = table.deepcopy(base_config)
+	etcd_config.apps.single.instances = {}
+	for instance_name, listen_uri in pairs(params.instances) do
+		etcd_config.apps.single.instances[instance_name] = { box = { listen = listen_uri } }
+	end
 
 	h.upload_to_etcd(etcd_config)
 
-	local base_env = {
-		TT_WAL_DIR = working_dir,
-		TT_MEMTX_DIR = working_dir,
-		TT_ETCD_PREFIX = '/apps/single',
-		TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
-		TT_MASTER_SELECTION_POLICY = 'etcd.instance.single',
-		TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
-	}
-	local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
-
-	for _, name in ipairs{'single_01', 'single_02'} do
+	for _, name in ipairs(params.run) do
 		local env = table.deepcopy(base_env)
 		env.TT_INSTANCE_NAME = name
 		local net_box_port = tonumber(uri.parse(etcd_config.apps.single.instances[name].box.listen).service)
@@ -111,7 +83,7 @@ function g.test_two_singles()
 			net_box_port = net_box_port,
 		})
 
-		table.insert(test_ctx.two_singles.tts, {
+		table.insert(this_ctx.tts, {
 			tt = tt,
 			net_box_port = net_box_port,
 			env = env,
@@ -119,13 +91,58 @@ function g.test_two_singles()
 		})
 	end
 
-	for _, tt in ipairs(test_ctx.two_singles.tts) do
+	for _, tt in ipairs(this_ctx.tts) do
 		tt.tt:connect_net_box()
 		local box_cfg = tt.tt:get_box_cfg()
 		t.assert_covers(box_cfg, {
-			log_level = 5,
+			log_level = etcd_config.apps.single.common.box.log_level,
 			listen = etcd_config.apps.single.instances[tt.name].box.listen,
-		})
+			read_only = false,
+		}, 'box.cfg is correct')
+
+		local conn = tt.tt --[[@as luatest.server]]
+		local ret = conn:exec(function()
+			local r = table.deepcopy(config.get('sys'))
+			for k, v in pairs(r) do
+				if type(v) == 'function' then
+					r[k] = nil
+				end
+			end
+			return r
+		end)
+
+		t.assert_covers(ret, {
+			instance_name = tt.name,
+			master_selection_policy = 'etcd.instance.single',
+			file = base_env.TT_CONFIG,
+		}, 'get("sys") has correct fields')
+	end
+
+	for _, tt in ipairs(this_ctx.tts) do
+		local conn = tt.tt --[[@as luatest.server]]
+		h.restart_tarantool(conn)
+
+		local box_cfg = tt.tt:get_box_cfg()
+		t.assert_covers(box_cfg, {
+			log_level = etcd_config.apps.single.common.box.log_level,
+			listen = etcd_config.apps.single.instances[tt.name].box.listen,
+			read_only = false,
+		}, 'box.cfg is correct after restart')
+
+		local ret = conn:exec(function()
+			local r = table.deepcopy(config.get('sys'))
+			for k, v in pairs(r) do
+				if type(v) == 'function' then
+					r[k] = nil
+				end
+			end
+			return r
+		end)
+
+		t.assert_covers(ret, {
+			instance_name = tt.name,
+			master_selection_policy = 'etcd.instance.single',
+			file = base_env.TT_CONFIG,
+		}, 'get("sys") has correct fields after restart')
 	end
 end
-

--- a/spec/01_single_test.lua
+++ b/spec/01_single_test.lua
@@ -77,6 +77,7 @@ function g.test_run_instances(cg)
 		local net_box_port = tonumber(uri.parse(etcd_config.apps.single.instances[name].box.listen).service)
 
 		local tt = h.start_tarantool({
+			alias = name,
 			env = env,
 			command = init_lua,
 			args = {},

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1,0 +1,117 @@
+local h = {}
+local t = require 'luatest' --[[@as luatest]]
+local fio = require 'fio'
+local log = require 'log'
+local fun = require 'fun'
+local clock = require 'clock'
+local fiber = require 'fiber'
+local http = require 'http.client'
+local json = require 'json'
+
+---Creates temporary working directory
+---@return string
+function h.create_workdir()
+	local tempdir = fio.tempdir()
+	assert(fio.mktree(tempdir))
+
+	return tempdir
+end
+
+---Removes all data in the path
+---@param path string
+function h.clean_directory(path)
+	if fio.path.is_dir(path) then
+		assert(fio.rmtree(path))
+	elseif fio.path.is_file(path) then
+		assert(fio.unlink(path))
+	end
+end
+
+---@param tree table
+---@param path string?
+---@param ret table<string,string|number|boolean>?
+---@return table<string,string|number|boolean>
+local function flatten(tree, path, ret)
+	path = path or ''
+	---@type table<string, string|number|boolean>
+	ret = ret or {}
+	for key, sub in pairs(tree) do
+		local base_type = type(sub)
+		if base_type ~= 'table' then
+			ret[path..'/'..key] = tostring(sub)
+		else
+			flatten(sub, path .. '/' .. key, ret)
+		end
+	end
+	return ret
+end
+
+---comment
+---@return EtcdCfg
+function h.get_etcd()
+	local endpoints = (os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379")
+		:gsub(",+", ",")
+		:gsub(',$','')
+		:split(',')
+
+	local etcd = require 'config.etcd':new{
+		endpoints = endpoints,
+		prefix = '/',
+		debug = true,
+	}
+
+	t.helpers.retrying({ timeout = 5 }, function() etcd:discovery() end)
+
+	return etcd
+end
+
+function h.clear_etcd()
+	local etcd = h.get_etcd()
+
+	local _, res = etcd:request('DELETE', 'keys/apps', { recursive = true, dir = true, force = true })
+	assert(res.status >= 200 and res.status < 300, ("%s %s"):format(res.status, res.body))
+end
+
+function h.upload_to_etcd(tree)
+	local etcd = h.get_etcd()
+
+	local flat = flatten(tree)
+	local keys = fun.totable(flat)
+	table.sort(keys)
+	for _, key in ipairs(keys) do
+		do
+			local _, res = etcd:request('PUT', 'keys'..key, { value = flat[key] })
+			log.info(res)
+			assert(res.status < 300 and res.status >= 200, res.reason)
+		end
+	end
+
+	local key = keys[1]:match('^(/[^/]+)')
+	log.info((etcd:list(key)))
+end
+
+---Starts new tarantool server
+---@param opts luatest.server.options
+---@return luatest.server
+function h.start_tarantool(opts)
+	log.info(opts)
+	local srv = t.Server:new(opts)
+	srv:start()
+
+	local process = srv.process
+
+	local deadline = clock.time() + 15
+	while clock.time() < deadline do
+		fiber.sleep(3)
+		assert(process:is_alive(), "tarantool is dead")
+
+		if pcall(function() srv:connect_net_box() end) then
+			break
+		end
+	end
+
+	return srv
+end
+
+
+return h

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -113,5 +113,25 @@ function h.start_tarantool(opts)
 	return srv
 end
 
+---comment
+---@param conn luatest.server
+function h.restart_tarantool(conn)
+	conn:stop()
+	local deadline = clock.time() + 15
+
+	fiber.sleep(3)
+	conn:start()
+
+	while clock.time() < deadline do
+		fiber.sleep(3)
+		assert(conn.process:is_alive(), "tarantool is dead")
+
+		if pcall(function() conn:connect_net_box() end) then
+			break
+		end
+
+	end
+end
+
 
 return h

--- a/spec/mock/single/conf.lua
+++ b/spec/mock/single/conf.lua
@@ -1,0 +1,13 @@
+local tt_etcd_endpoints = assert(os.getenv('TT_ETCD_ENDPOINTS'))
+local endpoints = tt_etcd_endpoints:gsub(',+', ','):gsub(',$',''):split(',')
+
+etcd = {
+	instance_name = instance_name,
+	endpoints = endpoints,
+	prefix = os.getenv('TT_ETCD_PREFIX'),
+}
+
+box = {
+	wal_dir = os.getenv('TT_WAL_DIR') ..'/' .. instance_name,
+	memtx_dir = os.getenv('TT_MEMTX_DIR') .. '/' .. instance_name,
+}

--- a/spec/mock/single/init.lua
+++ b/spec/mock/single/init.lua
@@ -1,0 +1,14 @@
+#!/usr/bin/env tarantool
+
+require 'config' {
+	mkdir = true,
+	print_config = true,
+	instance_name = os.getenv('TT_INSTANCE_NAME') or 'single',
+	file = os.getenv('TT_CONFIG'),
+	master_selection_policy = os.getenv('TT_MASTER_SELECTION_POLICY'),
+	on_after_cfg = function()
+		if not box.info.ro then
+			box.schema.user.grant('guest', 'super', nil, nil, { if_not_exists = true })
+		end
+	end,
+}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM tarantool/tarantool:2.10
+FROM tarantool/tarantool:1.10.14
 RUN apk add --no-cache -u iproute2 make bind-tools
 
 WORKDIR /opt/tarantool

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,3 @@
+
+run-compose:
+	docker compose up -d --remove-orphans --build

--- a/test/app/conf.lua
+++ b/test/app/conf.lua
@@ -1,7 +1,7 @@
 etcd = {
 	instance_name = os.getenv("TT_INSTANCE_NAME"),
 	prefix = '/instance',
-	endpoints = {"http://etcd:2379"},
+	endpoints = {"http://etcd0:2379","http://etcd1:2379","http://etcd2:2379"},
 	fencing_enabled = true,
 }
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -62,28 +62,28 @@ services:
       ETCD_ADVERTISE_CLIENT_URLS: http://etcd2:2379
       ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd2:2380
 
-  etcd_load:
-    image: registry.gitlab.com/ochaton/switchover:010a6965
-    networks:
-      - tarantool
-    volumes:
-      - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
-    depends_on:
-      etcd0:
-        condition: service_started
-      etcd1:
-        condition: service_started
-      etcd2:
-        condition: service_started
-    entrypoint: ['']
-    command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
-  instance_01:
-    <<: *tt
-    container_name: instance_01
-    environment:
-      TT_INSTANCE_NAME: instance_01
-  instance_02:
-    <<: *tt
-    container_name: instance_02
-    environment:
-      TT_INSTANCE_NAME: instance_02
+  # etcd_load:
+  #   image: registry.gitlab.com/ochaton/switchover:010a6965
+  #   networks:
+  #     - tarantool
+  #   volumes:
+  #     - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
+  #   depends_on:
+  #     etcd0:
+  #       condition: service_started
+  #     etcd1:
+  #       condition: service_started
+  #     etcd2:
+  #       condition: service_started
+  #   entrypoint: ['']
+  #   command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
+  # instance_01:
+  #   <<: *tt
+  #   container_name: instance_01
+  #   environment:
+  #     TT_INSTANCE_NAME: instance_01
+  # instance_02:
+  #   <<: *tt
+  #   container_name: instance_02
+  #   environment:
+  #     TT_INSTANCE_NAME: instance_02

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,19 +1,17 @@
 version: "3"
 
+x-env: &env
+  ETCDCTL_API: 2
+  ETCD_ENABLE_V2: true
+  ETCD_LISTEN_PEER_URLS: http://0.0.0.0:2380
+  ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+  ETCD_INITIAL_CLUSTER_TOKEN: etcd-cluster
+  ETCD_INITIAL_CLUSTER: etcd0=http://etcd0:2380,etcd1=http://etcd1:2380,etcd2=http://etcd2:2380
+
 x-etcd: &etcd
-  image: quay.io/coreos/etcd:v2.3.8
-  container_name: etcd
+  image: quay.io/coreos/etcd:v3.3.11
   networks:
     - tarantool
-  environment:
-    ETCD_LISTEN_PEER_URLS: http://0.0.0.0:2380
-    ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
-    ETCDCTL_API: 2
-    ETCD_INITIAL_CLUSTER_TOKEN: etcd-cluster
-    ETCD_INITIAL_CLUSTER: etcd=http://etcd:2380
-    ETCD_NAME: etcd
-    ETCD_ADVERTISE_CLIENT_URLS: http://etcd:2379
-    ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd:2380
 
 x-tt: &tt
   build: .
@@ -22,7 +20,11 @@ x-tt: &tt
     - $PWD/app:/opt/tarantool
     - $PWD/net:/opt/tarantool/net:ro
   depends_on:
-    etcd:
+    etcd0:
+      condition: service_started
+    etcd1:
+      condition: service_started
+    etcd2:
       condition: service_started
   privileged: true
   networks:
@@ -35,8 +37,31 @@ networks:
     driver: bridge
 
 services:
-  etcd:
+  etcd0:
     <<: *etcd
+    container_name: etcd0
+    environment:
+      <<: *env
+      ETCD_NAME: etcd0
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd0:2379
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd0:2380
+  etcd1:
+    <<: *etcd
+    container_name: etcd1
+    environment:
+      <<: *env
+      ETCD_NAME: etcd1
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd1:2379
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd1:2380
+  etcd2:
+    <<: *etcd
+    container_name: etcd2
+    environment:
+      <<: *env
+      ETCD_NAME: etcd2
+      ETCD_ADVERTISE_CLIENT_URLS: http://etcd2:2379
+      ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd2:2380
+
   etcd_load:
     image: registry.gitlab.com/ochaton/switchover:010a6965
     networks:
@@ -44,10 +69,14 @@ services:
     volumes:
       - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
     depends_on:
-      etcd:
+      etcd0:
+        condition: service_started
+      etcd1:
+        condition: service_started
+      etcd2:
         condition: service_started
     entrypoint: ['']
-    command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd:2379 etcd load / /instance.etcd.yaml"]
+    command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
   instance_01:
     <<: *tt
     container_name: instance_01

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -62,28 +62,28 @@ services:
       ETCD_ADVERTISE_CLIENT_URLS: http://etcd2:2379
       ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd2:2380
 
-  # etcd_load:
-  #   image: registry.gitlab.com/ochaton/switchover:010a6965
-  #   networks:
-  #     - tarantool
-  #   volumes:
-  #     - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
-  #   depends_on:
-  #     etcd0:
-  #       condition: service_started
-  #     etcd1:
-  #       condition: service_started
-  #     etcd2:
-  #       condition: service_started
-  #   entrypoint: ['']
-  #   command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
-  # instance_01:
-  #   <<: *tt
-  #   container_name: instance_01
-  #   environment:
-  #     TT_INSTANCE_NAME: instance_01
-  # instance_02:
-  #   <<: *tt
-  #   container_name: instance_02
-  #   environment:
-  #     TT_INSTANCE_NAME: instance_02
+  etcd_load:
+    image: registry.gitlab.com/ochaton/switchover:010a6965
+    networks:
+      - tarantool
+    volumes:
+      - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
+    depends_on:
+      etcd0:
+        condition: service_started
+      etcd1:
+        condition: service_started
+      etcd2:
+        condition: service_started
+    entrypoint: ['']
+    command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
+  instance_01:
+    <<: *tt
+    container_name: instance_01
+    environment:
+      TT_INSTANCE_NAME: instance_01
+  instance_02:
+    <<: *tt
+    container_name: instance_02
+    environment:
+      TT_INSTANCE_NAME: instance_02

--- a/test/instance.etcd.yaml
+++ b/test/instance.etcd.yaml
@@ -7,7 +7,7 @@ instance:
   common:
     etcd:
       fencing_timeout: 10
-      fencing_pause: 7
+      fencing_pause: 5
     box:
       replication_connect_quorum: 1
       log_level: 5


### PR DESCRIPTION
* Apparently config/etcd on receiving HTTP timeout (408) retries
	other endpoints. Now `fencing_check` decreases timeout encounting
	number of connected instances
* Decreased `log_level` when `etcd/wait` returned something not 408
	it should help to investigate network issues
* All sleep timeouts now adjusted to help fencing mechanism survive high CPU-load and still make at least 1 `etcd/list` request during `fencing_timeout` deadline