### PR TITLE
draft: fixes fencing and hot-reload in 2.11+

### DIFF
--- a/.github/workflows/push-rockspec.yml
+++ b/.github/workflows/push-rockspec.yml
@@ -10,9 +10,9 @@ env:
 
 jobs:
   pack-and-push-tagged-rockspec:
-   runs-on: ubuntu-latest
-   if: startsWith(github.ref, 'refs/tags')
-   steps:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
     - uses: actions/checkout@master
     - uses: tarantool/setup-tarantool@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Create and push rockspec for moonlibs/config
+
+on:
+  push:
+
+env:
+  ROCK_NAME: config
+
+jobs:
+  test-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["1.10.15", "2.8.4", "2.10.6", "2.11.0", "2.11.1"]
+    steps:
+    - uses: actions/checkout@master
+    - uses: docker/setup-buildx-action@v2
+    - name: run test suite for ${{matrix.version}}
+      run: make test-${{matrix.version}}

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,6 @@
+FROM tarantool/tarantool:2.10 as builder
+RUN apk add -u git cmake make gcc musl-dev curl wget
+WORKDIR /root
+RUN tarantoolctl rocks install luatest scm-1
+RUN tarantoolctl rocks install luacov-console 1.1.0
+RUN tarantoolctl rocks --server https://moonlibs.github.io/rocks install package-reload scm-1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,8 @@
-FROM tarantool/tarantool:2.10
+ARG IMAGE=1.10.14
+FROM config-test-builder as builder
 
-RUN apk add -u git cmake make gcc musl-dev
-RUN tarantoolctl rocks install luatest 0.5.7
-RUN tarantoolctl rocks install luacov-console
+FROM tarantool/tarantool:${IMAGE}
+
+WORKDIR /root
+COPY --from=builder /root/.rocks /root/.rocks
+WORKDIR /opt/tarantool

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 .PHONY := all test
 
-run-compose:
-	make -C test run-compose
+run-etcd:
+	make -C test run-compose-etcd
 
-build-testing-image:
-	docker build -t config-test -f Dockerfile.test .
+config-test-builder:
+	docker build -t config-test-builder -f Dockerfile.build .
 
-test: build-testing-image run-compose
-	docker run --name config-test \
+config-test-%: config-test-builder run-etcd
+	docker build -t $(@) --build-arg IMAGE=$(subst config-test-,,$@) -f Dockerfile.test .
+
+test-%: config-test-%
+	docker run -it --name $(<) \
 		--net tt_net \
 		-e TT_ETCD_ENDPOINTS="http://etcd0:2379,http://etcd1:2379,http://etcd2:2379" \
 		--rm -v $$(pwd):/source/config \
 		-v $$(pwd)/data:/tmp/ \
 		--workdir /source/config \
 		--entrypoint '' \
-		config-test \
+		$(<) \
 		./run_test_in_docker.sh

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ config-test-%: config-test-builder run-etcd
 	docker build -t $(@) --build-arg IMAGE=$(subst config-test-,,$@) -f Dockerfile.test .
 
 test-%: config-test-%
-	docker run -it --name $(<) \
+	docker run --name $(<) \
 		--net tt_net \
 		-e TT_ETCD_ENDPOINTS="http://etcd0:2379,http://etcd1:2379,http://etcd2:2379" \
 		--rm -v $$(pwd):/source/config \

--- a/config/etcd.lua
+++ b/config/etcd.lua
@@ -1,6 +1,7 @@
 local json = require 'json'
 local log = require 'log'
 local fiber = require 'fiber'
+local clock = require 'clock'
 
 local http_client = require 'http.client'
 local digest = require 'digest'
@@ -51,6 +52,7 @@ end
 setmetatable(M,{ __call = M.new })
 
 function M:discovery()
+	local start_at = clock.time()
 	local timeout = self.timeout or 1
 	local new_endpoints = {}
 	local tried = {}
@@ -83,14 +85,14 @@ function M:discovery()
 		end
 	end
 	if #new_endpoints == 0 then
-		error("Failed to discover members "..table.concat(tried,", "),2)
+		error("Failed to discover members "..table.concat(tried,", ")..(" in %.3fs"):format(clock.time()-start_at),2)
 	end
 	if self.discover_endpoints then
 		self.endpoints = new_endpoints
 		table.insert(self.endpoints,table.remove(self.endpoints,1))
-		log.info("discovered etcd endpoints "..table.concat(self.endpoints,", "))
+		log.info("discovered etcd endpoints "..table.concat(self.endpoints,", ")..(" in %.3fs"):format(clock.time()-start_at))
 	else
-		log.info("hardcoded etcd endpoints "..table.concat(self.endpoints,", "))
+		log.info("hardcoded etcd endpoints "..table.concat(self.endpoints,", ")..(" in %.3fs"):format(clock.time()-start_at))
 	end
 	self.current = math.random(#self.endpoints)
 end

--- a/run_test_in_docker.sh
+++ b/run_test_in_docker.sh
@@ -2,4 +2,5 @@
 
 pwd
 rm -rf /root/.cache/
-.rocks/bin/luatest --coverage -c -v spec/01_single_test.lua
+cp -ar /root/.rocks /source/config/.rocks
+/source/config/.rocks/bin/luatest --coverage -v spec/

--- a/spec/02_cluster_master_test.lua
+++ b/spec/02_cluster_master_test.lua
@@ -1,0 +1,190 @@
+local t = require 'luatest' --[[@as luatest]]
+local uuid = require 'uuid'
+
+---@class test.config.master:luatest.group
+local g = t.group('master', {
+	{
+		cluster = 'single',
+		master = 'first_01',
+		instances = {first_01 = '127.0.0.1:3301', first_02 = '127.0.0.1:3302'},
+		run = {'first_01', 'first_02'}
+	},
+	{
+		cluster = 'single',
+		master = 'second_01',
+		instances = {second_01 = '127.0.0.1:3301', second_02 = '127.0.0.1:3302'},
+		run = {'second_01'}
+	},
+	{
+		cluster = 'single',
+		master = 'third_01',
+		instances = {third_01 = '127.0.0.1:3301', third_02 = '127.0.0.1:3302',third_03='127.0.0.1:3303'},
+		run = {'third_03','third_02','third_01'}
+	},
+})
+
+local this_file = debug.getinfo(1, "S").source:sub(2)
+local fio = require 'fio'
+
+local root = fio.dirname(this_file)
+local init_lua = fio.pathjoin(root, 'mock', 'single', 'init.lua')
+
+local base_env
+
+local h = require 'spec.helper'
+local test_ctx = {}
+
+g.before_each(function(cg)
+	local working_dir = h.create_workdir()
+	base_env = {
+		TT_ETCD_PREFIX = '/apps/single',
+		TT_CONFIG = fio.pathjoin(root, 'mock', 'single', 'conf.lua'),
+		TT_MASTER_SELECTION_POLICY = 'etcd.cluster.master',
+		TT_ETCD_ENDPOINTS = os.getenv('TT_ETCD_ENDPOINTS') or "http://127.0.0.1:2379",
+	}
+
+	base_env.TT_WAL_DIR = working_dir
+	base_env.TT_MEMTX_DIR = working_dir
+
+	local base_config = {
+		etcd = {
+			fencing_enabled = true,
+		},
+		apps = {
+			single = {
+				common = { box = { log_level = 1 } },
+				clusters = {
+					single = {
+						master = cg.params.master,
+						replicaset_uuid = uuid.str(),
+					}
+				},
+			}
+		},
+	}
+	h.clear_etcd()
+
+	local etcd_config = table.deepcopy(base_config)
+	etcd_config.apps.single.instances = {}
+	for instance_name, listen_uri in pairs(cg.params.instances) do
+		etcd_config.apps.single.instances[instance_name] = {
+			box = { listen = listen_uri },
+			cluster = cg.params.cluster,
+		}
+	end
+
+	local this_ctx = { tts = {}, env = base_env, etcd_config = etcd_config, params = cg.params }
+	test_ctx[cg.name] = this_ctx
+
+	h.upload_to_etcd(etcd_config)
+end)
+
+g.after_each(function()
+	for _, info in pairs(test_ctx) do
+		for _, tt in pairs(info.tts) do
+			tt.server:stop()
+		end
+		h.clean_directory(info.env.TT_WAL_DIR)
+		h.clean_directory(info.env.TT_MEMTX_DIR)
+	end
+
+	h.clear_etcd()
+end)
+
+function g.test_run_instances(cg)
+	local ctx = test_ctx[cg.name]
+
+	-- Start tarantools
+	h.start_all_tarantools(ctx, init_lua, root, ctx.etcd_config.apps.single.instances)
+
+	-- Check configuration
+	for _, tnt in ipairs(ctx.tts) do
+		tnt.server:connect_net_box()
+		local box_cfg = tnt.server:get_box_cfg()
+		t.assert_covers(box_cfg, {
+			log_level = ctx.etcd_config.apps.single.common.box.log_level,
+			listen = ctx.etcd_config.apps.single.instances[tnt.name].box.listen,
+			read_only = ctx.etcd_config.apps.single.clusters.single.master ~= tnt.name,
+		}, 'box.cfg is correct')
+
+		local conn = tnt.server --[[@as luatest.server]]
+		local ret = conn:exec(function()
+			local r = table.deepcopy(config.get('sys'))
+			for k, v in pairs(r) do
+				if type(v) == 'function' then
+					r[k] = nil
+				end
+			end
+			return r
+		end)
+
+		t.assert_covers(ret, {
+			instance_name = tnt.name,
+			master_selection_policy = 'etcd.cluster.master',
+			file = base_env.TT_CONFIG,
+		}, 'get("sys") has correct fields')
+	end
+
+	-- restart+check configuration
+	for _, tt in ipairs(ctx.tts) do
+		h.restart_tarantool(tt.server)
+
+		local box_cfg = tt.server:get_box_cfg()
+		t.assert_covers(box_cfg, {
+			log_level = ctx.etcd_config.apps.single.common.box.log_level,
+			listen = ctx.etcd_config.apps.single.instances[tt.name].box.listen,
+			read_only = ctx.etcd_config.apps.single.clusters.single.master ~= tt.name,
+		}, 'box.cfg is correct after restart')
+
+		local ret = tt.server:exec(function()
+			local r = table.deepcopy(config.get('sys'))
+			for k, v in pairs(r) do
+				if type(v) == 'function' then
+					r[k] = nil
+				end
+			end
+			return r
+		end)
+
+		t.assert_covers(ret, {
+			instance_name = tt.name,
+			master_selection_policy = 'etcd.cluster.master',
+			file = base_env.TT_CONFIG,
+		}, 'get("sys") has correct fields after restart')
+	end
+end
+
+function g.test_reload(cg)
+	local ctx = test_ctx[cg.name]
+
+	-- Start tarantools
+	h.start_all_tarantools(ctx, init_lua, root, ctx.etcd_config.apps.single.instances)
+
+	-- reload+check configuration
+	for _, tt in ipairs(ctx.tts) do
+		h.reload_tarantool(tt.server)
+
+		local box_cfg = tt.server:get_box_cfg()
+		t.assert_covers(box_cfg, {
+			log_level = ctx.etcd_config.apps.single.common.box.log_level,
+			listen = ctx.etcd_config.apps.single.instances[tt.name].box.listen,
+			read_only = ctx.etcd_config.apps.single.clusters.single.master ~= tt.name,
+		}, 'box.cfg is correct after restart')
+
+		local ret = tt.server:exec(function()
+			local r = table.deepcopy(config.get('sys'))
+			for k, v in pairs(r) do
+				if type(v) == 'function' then
+					r[k] = nil
+				end
+			end
+			return r
+		end)
+
+		t.assert_covers(ret, {
+			instance_name = tt.name,
+			master_selection_policy = 'etcd.cluster.master',
+			file = base_env.TT_CONFIG,
+		}, 'get("sys") has correct fields after restart')
+	end
+end

--- a/spec/mock/single/init.lua
+++ b/spec/mock/single/init.lua
@@ -1,9 +1,9 @@
 #!/usr/bin/env tarantool
-
+require 'package.reload'
 require 'config' {
 	mkdir = true,
 	print_config = true,
-	instance_name = os.getenv('TT_INSTANCE_NAME') or 'single',
+	instance_name = os.getenv('TT_INSTANCE_NAME'),
 	file = os.getenv('TT_CONFIG'),
 	master_selection_policy = os.getenv('TT_MASTER_SELECTION_POLICY'),
 	on_after_cfg = function()

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,7 @@
-FROM tarantool/tarantool:1.10.14
+FROM tarantool/tarantool:2.11
 RUN apk add --no-cache -u iproute2 make bind-tools
 
 WORKDIR /opt/tarantool
+RUN tarantoolctl rocks --global --server http://moonlibs.github.io/rocks install package-reload scm-1
 
 CMD ["tarantool" "/opt/tarantool/init.lua"]

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,6 @@
 
-run-compose:
+run-compose-etcd:
+	docker compose up -d --remove-orphans --build etcd0 etcd1 etcd2
+
+run-compose: run-compose-etcd
 	docker compose up -d --remove-orphans --build

--- a/test/app/conf.lua
+++ b/test/app/conf.lua
@@ -3,6 +3,7 @@ etcd = {
 	prefix = '/instance',
 	endpoints = {"http://etcd0:2379","http://etcd1:2379","http://etcd2:2379"},
 	fencing_enabled = true,
+	timeout = 2,
 }
 
 box = {

--- a/test/app/init.lua
+++ b/test/app/init.lua
@@ -1,5 +1,6 @@
 local fiber = require "fiber"
 
+require 'package.reload'
 require 'config' {
 	mkdir = true,
 	print_config = true,

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -13,23 +13,23 @@ x-etcd: &etcd
   networks:
     - tarantool
 
-x-tt: &tt
-  build: .
-  volumes:
-    - $PWD/../:/opt/tarantool/.rocks/share/tarantool:ro
-    - $PWD/app:/opt/tarantool
-    - $PWD/net:/opt/tarantool/net:ro
-  depends_on:
-    etcd0:
-      condition: service_started
-    etcd1:
-      condition: service_started
-    etcd2:
-      condition: service_started
-  privileged: true
-  networks:
-    - tarantool
-  command: ["/bin/sh", "-c", "sleep 5 && tarantool /opt/tarantool/init.lua"]
+# x-tt: &tt
+#   build: .
+#   volumes:
+#     - $PWD/../:/opt/tarantool/.rocks/share/tarantool:ro
+#     - $PWD/app:/opt/tarantool
+#     - $PWD/net:/opt/tarantool/net:ro
+#   depends_on:
+#     etcd0:
+#       condition: service_started
+#     etcd1:
+#       condition: service_started
+#     etcd2:
+#       condition: service_started
+#   privileged: true
+#   networks:
+#     - tarantool
+#   command: ["/bin/sh", "-c", "sleep 5 && tarantool /opt/tarantool/init.lua"]
 
 networks:
   tarantool:
@@ -62,28 +62,28 @@ services:
       ETCD_ADVERTISE_CLIENT_URLS: http://etcd2:2379
       ETCD_INITIAL_ADVERTISE_PEER_URLS: http://etcd2:2380
 
-  etcd_load:
-    image: registry.gitlab.com/ochaton/switchover:010a6965
-    networks:
-      - tarantool
-    volumes:
-      - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
-    depends_on:
-      etcd0:
-        condition: service_started
-      etcd1:
-        condition: service_started
-      etcd2:
-        condition: service_started
-    entrypoint: ['']
-    command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
-  instance_01:
-    <<: *tt
-    container_name: instance_01
-    environment:
-      TT_INSTANCE_NAME: instance_01
-  instance_02:
-    <<: *tt
-    container_name: instance_02
-    environment:
-      TT_INSTANCE_NAME: instance_02
+  # etcd_load:
+  #   image: registry.gitlab.com/ochaton/switchover:2.7.0.20
+  #   networks:
+  #     - tarantool
+  #   volumes:
+  #     - $PWD/instance.etcd.yaml:/instance.etcd.yaml:ro
+  #   depends_on:
+  #     etcd0:
+  #       condition: service_started
+  #     etcd1:
+  #       condition: service_started
+  #     etcd2:
+  #       condition: service_started
+  #   entrypoint: ['']
+  #   command: ["/bin/sh", "-c", "sleep 3 && switchover -v -e http://etcd0:2379,http://etcd1:2379,http://etcd2:2379 etcd load / /instance.etcd.yaml"]
+  # instance_01:
+  #   <<: *tt
+  #   container_name: instance_01
+  #   environment:
+  #     TT_INSTANCE_NAME: instance_01
+  # instance_02:
+  #   <<: *tt
+  #   container_name: instance_02
+  #   environment:
+  #     TT_INSTANCE_NAME: instance_02


### PR DESCRIPTION

* DFixes start/restart and reload for Tarantool 2.11. Valid path to retrieve default_cfg and template_cfg is `{mt_call, reload_cfg, reconfig_modules}`
* Adds wall-clock timings for `etcd_load` call to simplify investigations of issues related to "smthing happened to tarantool-etcd"
* Fencing: now immediately step-downs when another master is discovered in ETCD. Previously it was waiting until previous `fencing_timeout` is exhausted
* config/etcd:request now respects optional argument `deadline` and is used to adjust request-timeout in listings
* And finally introduces integration test setup to ensure safety of further patches in config

@Mons , please have a look. And do not merge yet :) 