### PR TITLE
Allow disable fencing with etcd.fencing_enabled: false

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1129,7 +1129,7 @@ local M
 
 			local msp = config.get('sys.master_selection_policy')
 			if type(cfg.etcd) == 'table'
-				and config.get('etcd.fencing_enabled')
+				and config.get('etcd.fencing_enabled') == true
 				and (msp == 'etcd.cluster.master' or msp == 'etcd.cluster.vshard')
 				and type(cfg.cluster) == 'string' and cfg.cluster ~= ''
 				and config.get('etcd.reduce_listing_quorum') ~= true


### PR DESCRIPTION
It is confused when fencing just works if setting is actually `etcd.fencing_enabled: false`.