### PR TITLE
Provide override-config rockspecs

### DIFF
--- a/.github/workflows/push-rockspec.yml
+++ b/.github/workflows/push-rockspec.yml
@@ -14,7 +14,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
     - uses: actions/checkout@master
-    - uses: tarantool/setup-tarantool@v2
+    - uses: tarantool/setup-tarantool@v3
       with:
         tarantool-version: '2.6'
 
@@ -25,6 +25,10 @@ jobs:
     - run: tarantoolctl rocks new_version --tag=${{ env.TAG }} rockspecs/config-scm-5.rockspec ${{ env.TAG }} "git+https://github.com/${{ github.repository }}.git"
     - run: tarantoolctl rocks --server https://moonlibs.github.io/rocks install ${{ env.ROCK_NAME }}-${{ env.TAG }}-1.rockspec
     - run: tarantoolctl rocks pack ${{ env.ROCK_NAME }}-${{ env.TAG }}-1.rockspec
+
+    - run: tarantoolctl rocks new_version --tag=${{ env.TAG }} override-config-dev-1.rockspec ${{ env.TAG }} "git+https://github.com/${{ github.repository }}.git"
+    - run: tarantoolctl rocks --server https://moonlibs.github.io/rocks install override-config-${{ env.TAG }}-1.rockspec
+    - run: tarantoolctl rocks pack override-config-${{ env.TAG }}-1.rockspec
     # Install native lua with luarocks
     - uses: leafo/gh-actions-lua@v9
       with:
@@ -33,11 +37,11 @@ jobs:
       with:
         luarocksVersion: "3.8.0"
     - uses: unfor19/install-aws-cli-action@v1.0.3
-    - run: mkdir .build && cp ${{env.ROCK_NAME}}-dev-1.rockspec ${{env.ROCK_NAME}}-${{env.TAG}}-1.rockspec .build/ && cp *.src.rock .build/
+    - run: mkdir .build && cp ${{env.ROCK_NAME}}-dev-1.rockspec ${{env.ROCK_NAME}}-${{env.TAG}}-1.rockspec ${{env.ROCK_NAME}}-${{env.TAG}}-1.src.rock .build/
     - name: rebuild and publish s3 luarocks server
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.MOONLIBS_S3_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.MOONLIBS_S3_SECRET_KEY}}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.MOONLIBS_S3_SECRET_KEY }}
         AWS_EC2_METADATA_DISABLED: true
       run: |
         cd .build && aws s3 sync s3://moonlibs/ ./ && luarocks-admin make_manifest . && aws s3 sync --acl public-read ./ s3://moonlibs/;
@@ -50,3 +54,6 @@ jobs:
           ${{env.ROCK_NAME}}-dev-1.rockspec
           ${{env.ROCK_NAME}}-${{env.TAG}}-1.rockspec
           ${{env.ROCK_NAME}}-${{env.TAG}}-1.src.rock
+          override-${{env.ROCK_NAME}}-dev-1.rockspec
+          override-${{env.ROCK_NAME}}-${{env.TAG}}-1.rockspec
+          override-${{env.ROCK_NAME}}-${{env.TAG}}-1.src.rock

--- a/override-config-dev-1.rockspec
+++ b/override-config-dev-1.rockspec
@@ -1,0 +1,21 @@
+package = "override-config"
+version = "dev-1"
+source = {
+   url = "git+https://github.com/moonlibs/config",
+   branch = "master"
+}
+description = {
+   summary = "Package for loading external lua config (override)",
+   homepage = "https://github.com/moonlibs/config.git",
+   license = "BSD"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["override.config"] = "config.lua",
+      ["override.config.etcd"] = "config/etcd.lua"
+   }
+}


### PR DESCRIPTION
Someone wanted to use moonlibs/config instead of tarantool/config.

Provide separate rockspec and rocks which should never be published to rocks_server but provided during each release statically